### PR TITLE
chore(automotive): add Autoware applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Zenoh is designed to provide a unified abstraction for pub/sub, query/reply, and
 - [`zenoh-plugin-dds`](https://github.com/eclipse-zenoh/zenoh-plugin-dds) – Bridge between Zenoh and DDS.
 - [`zenoh-plugin-rest`](https://github.com/eclipse-zenoh/zenoh-plugin-rest) – RESTful API plugin for Zenoh.
 - [`zenoh-bridge-mqtt`](https://github.com/eclipse-zenoh/zenoh-bridge-mqtt) – Bridge between MQTT and Zenoh.
-- [`liason`](https://github.com/RISE-Maritime/liaison) - Simplify the sharing of Functional Mock-up Units (FMUs) both within and between organizations. 
+- [`liason`](https://github.com/RISE-Maritime/liaison) - Simplify the sharing of Functional Mock-up Units (FMUs) both within and between organizations.
 - [`gatorcat`](https://github.com/kj4tmp/gatorcat) - EtherCAT maindevice written in Zig with Zenoh connectivity.
 
 ---
@@ -102,7 +102,7 @@ Zenoh is designed to provide a unified abstraction for pub/sub, query/reply, and
 
 ## Command Line Tool
 
-- [`zenoh-cli`](https://github.com/RISE-Maritime/zenoh-cli) – A Python-based commandline tool to interact with a Zenoh Session. 
+- [`zenoh-cli`](https://github.com/RISE-Maritime/zenoh-cli) – A Python-based commandline tool to interact with a Zenoh Session.
 - [`zsak`](http://github.com/kydos/zsak) - Zenoh Swiss Army Knife, a Rust-based commandline tool that can be used to learn Zenoh.
 
 ---
@@ -121,6 +121,8 @@ Zenoh is designed to provide a unified abstraction for pub/sub, query/reply, and
   - [up-transport-zenoh-cpp](https://github.com/eclipse-uprotocol/up-transport-zenoh-cpp) - C++ implementation.
 - [zenoh_autoware_fms](https://github.com/evshary/zenoh_autoware_fms) - Project to showcase an Autoware fleet management system with Zenoh.
 - [zenoh_autoware_v2x](https://github.com/evshary/zenoh_autoware_v2x) - Project to showcase an Autoware V2X scenario with Zenoh.
+- [`zenoh_carla_bridge`](https://github.com/evshary/zenoh_carla_bridge) - Bridge Autoware and Carla with Zenoh.
+- [`autoware_rmw_zenoh`](https://github.com/evshary/autoware_rmw_zenoh) - Tutorial for running Autoware with [rmw_zenoh](http://github.com/ros2/rmw_zenoh).
 
 ---
 


### PR DESCRIPTION
This PR aims to add two Autoware applications on top of Zenoh, plus some minor trailing space removal.

- [`zenoh_carla_bridge`](https://github.com/evshary/zenoh_carla_bridge) - Bridge Autoware and Carla with Zenoh.
- [`autoware_rmw_zenoh`](https://github.com/evshary/autoware_rmw_zenoh) - Tutorial for running Autoware with [rmw_zenoh](http://github.com/ros2/rmw_zenoh).