### PR TITLE
Add Zenohex on Community API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Zenoh is designed to provide a unified abstraction for pub/sub, query/reply, and
 
 - [`zenoh-jl`](https://github.com/BenChung/Zenoh.jl) - Julia binding for Zenoh Rust.
 - [`zenoh-csharp`](https://github.com/sanri/zenoh-csharp) - Zenoh-CS provides the common interface of Zenoh-C.
+- [`zenohex`](https://github.com/biyooon-ex/zenohex) - Elixir binding for Zenoh Rust.
 
 ---
 


### PR DESCRIPTION
Thank you so much for publishing an awesome repository! This is definitely what we need:D

This PR wants to add our repository [Zenohex](https://github.com/biyooon-ex/zenohex), which is an Elixir API for Zenoh. Elixir is one of the functional languages operating in the Erlang VM. The version of Zenoh that our library supports is still old (v0.11.0), but we are working to bring it up to date (v1.3 or v1.4).
I would be happy to have it added to this list as one of the APIs being developed by the community. 