### PR TITLE
Add zenoh-plugin-grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Zenoh is designed to provide a unified abstraction for pub/sub, query/reply, and
 - [`liason`](https://github.com/RISE-Maritime/liaison) - Simplify the sharing of Functional Mock-up Units (FMUs) both within and between organizations.
 - [`gatorcat`](https://github.com/kj4tmp/gatorcat) - EtherCAT maindevice written in Zig with Zenoh connectivity.
 - ['nodered-contrib-zenoh'](https://github.com/freol35241/nodered-contrib-zenoh) - Zenoh in Node-RED
+- [`zenoh-plugin-grpc`](https://github.com/shupx/zenoh-plugin-grpc.git) - Expose zenoh API via gRPC calls.
 
 ---
 


### PR DESCRIPTION
Add zenoh-plugin-grpc, which is personally developed by me.

This plugin starts a gRPC server inside zenohd and exposes Zenoh operations over gRPC so that external applications (python/c++) can interact with Zenoh via gRPC calls. 

This is useful for one zenoh peer/router acting as a communication bridge and multiple external (local) applications connecting to it to send and receive messages.

SDKs for gRPC clients are also provided in rust (core), python, C, and C++ (thin bindings).
